### PR TITLE
Added radial gradient handling.

### DIFF
--- a/src/leaflet.dvf.markers.js
+++ b/src/leaflet.dvf.markers.js
@@ -150,7 +150,6 @@ var PathFunctions = PathFunctions || {
 	},
 
 	_createGradient: function (options) {
-
 		if (!this._defs) {
 			this._createDefs();
 		};
@@ -159,21 +158,26 @@ var PathFunctions = PathFunctions || {
 			this._defs.removeChild(this._gradient);
 		}
 
-		var gradient = this._createElement('linearGradient');
+		options = options !== true ? L.extend({}, options) : {};
 		var gradientGuid = L.Util.guid();
 		this._gradientGuid = gradientGuid;
 
-		options = options !== true ? L.extend({}, options) : {};
-
-		var vector = options.vector || [['0%','0%'], ['100%','100%']];
-		var vectorOptions = {
-			x1: vector[0][0],
-			x2: vector[1][0],
-			y1: vector[0][1],
-			y2: vector[1][1]
-		};
-
-		vectorOptions.id = 'grad' + gradientGuid;
+		var gradient;
+		var gradientOptions;
+		if (options.gradientType == "radial") {
+			gradient = this._createElement("radialGradient");
+			var gradientOptions = options.radial || { cx: '50%', cy: '50%', r: '50%', fx: '50%', fy: '50%' };
+		} else {
+			gradient = this._createElement("linearGradient");
+			var vector = options.vector || [ [ "0%", "0%" ], [ "100%", "100%" ] ];
+			var gradientOptions = {
+				x1: vector[0][0],
+				x2: vector[1][0],
+				y1: vector[0][1],
+				y2: vector[1][1]
+			};
+		}
+		gradientOptions.id = "grad" + gradientGuid;
 
 		var stops = options.stops || [
 			{
@@ -192,8 +196,8 @@ var PathFunctions = PathFunctions || {
 			}
 		];
 
-		for (var key in vectorOptions) {
-			gradient.setAttribute(key, vectorOptions[key]);
+		for (var key in gradientOptions) {
+			gradient.setAttribute(key, gradientOptions[key]);
 		}
 
 		for (var i = 0; i < stops.length; ++i) {


### PR DESCRIPTION
For presentation purposes we needed a radial gradient for a shape to allow a written text over the shape to be readable independent of the color of the shape. An example result is shown in the image below.
![image](https://cloud.githubusercontent.com/assets/7868114/4057765/28e5f3ae-2dcd-11e4-8965-7868575fc567.png)

Could you pull this change?
Thanks.
Best regards, 

Michiel
