### PR TITLE
'clickable' has been renamed to 'interactive' in 1.0b1

### DIFF
--- a/src/leaflet.dvf.datalayer.js
+++ b/src/leaflet.dvf.datalayer.js
@@ -435,7 +435,7 @@ L.DataLayer = L.LayerGroup.extend({
 
             style = style || this.options.boundaryStyle || L.extend({}, options, {
                 fillOpacity: 0.2,
-                clickable: false
+                interactive: false
             });
 
             layer.setStyle(style);


### PR DESCRIPTION
See note in https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#layers-api-improvements
"Renamed clickable option to interactive (by @AndriiHeonia). #2838 #2499"