### PR TITLE
fix signature shift in recursive call

### DIFF
--- a/src/leaflet.dvf.utils.js
+++ b/src/leaflet.dvf.utils.js
@@ -779,7 +779,7 @@ L.HTMLUtils = {
 				var value = obj[property];
 				if (typeof value === 'object') {
 					var container = document.createElement('div');
-					container.appendChild(L.HTMLUtils.buildTable(value, ignoreFields));
+					container.appendChild(L.HTMLUtils.buildTable(value, className, ignoreFields));
 					value = container.innerHTML;
 				}
 				


### PR DESCRIPTION
In L.HTMLUtils.buildTable, the recursive call loses the ingnoredFields argument for nested structures.