### PR TITLE
Update L.Graph to use location.text

### DIFF
--- a/src/leaflet.dvf.experimental.js
+++ b/src/leaflet.dvf.experimental.js
@@ -718,7 +718,7 @@ L.Graph = L.Graph.extend({
 				location = {
 					center: bounds.getCenter(),
 					location: line,
-					text: fromValue + ' - ' + toValue
+					text: fromLocation.text + ' - ' + toLocation.text
 				};
 			}
 		}


### PR DESCRIPTION
Update L.Graph to use location.text instead of value field value when creating new location objects. This allows the CUSTOM function to use the location.text value to customize tooltip titles.